### PR TITLE
idl/codegen: fix zero-argument methods in interfaces with mixed arity

### DIFF
--- a/tools/build/src/idl/codegen.rs
+++ b/tools/build/src/idl/codegen.rs
@@ -448,9 +448,13 @@ fn generate_server_op_enum(iface: &InterfaceDef) -> miette::Result<(Ident, proc_
                 <#ty as hubpack::SerializedSize>::MAX_SIZE
             })
         }).collect::<miette::Result<Vec<_>>>()?;
-        Ok(quote::quote! {
-            #(#args)+*
-        })
+        if args.is_empty() {
+            Ok(quote::quote! { 0usize })
+        } else {
+            Ok(quote::quote! {
+                #(#args)+*
+            })
+        }
     }).collect::<miette::Result<Vec<_>>>()?;
     let reply_cases = iface.methods.iter().map(|(name, def)| {
         let discrim = format_ident!("{}", name.to_case(Case::Pascal));


### PR DESCRIPTION
Methods with no arguments produce an empty token stream in the `incoming_sizes` array, which becomes a bare comma when the interface also has methods with arguments, e.g. `const_max(&[size, , ,])`. 1f237c0 handles interfaces with all zero args, but not a mix.